### PR TITLE
Update issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,34 @@
+---
+name: Bug report
+about: Create a report to help us improve
+title: "[BUG]: "
+labels: bug
+assignees: ''
+
+---
+
+**Describe the bug**
+A clear and concise description of what the bug is.
+
+**To Reproduce**
+Steps to reproduce the behavior:
+1. Go to '...'
+2. Click on '....'
+3. Scroll down to '....'
+4. See error
+
+**Expected behavior**
+A clear and concise description of what you expected to happen.
+
+**Screenshots**
+If applicable, add screenshots to help explain your problem.
+
+**Desktop (please complete the following information):**
+ - OS: [e.g. macOS]
+ - Browser [e.g. chrome, safari]
+ - Version [e.g. 22]
+ - Node version
+ - NPM version
+
+**Additional context**
+Add any other context about the problem here.


### PR DESCRIPTION
Adds an Issue template based on template in feedback page on docs to save the opener having to copy-paste or retype it.

https://ibm.github.io/spm-ui-addon-devenv/feedback/